### PR TITLE
 Update Glacier IAM conditions documentation

### DIFF
--- a/doc_source/access-control-overview.md
+++ b/doc_source/access-control-overview.md
@@ -153,9 +153,6 @@ When you grant permissions, you can use the IAM policy language to specify the c
 
 AWS provides a set of predefined condition keys, called *AWS\-wide condition keys*, for all AWS services that support IAM for access control\. AWS\-wide condition keys use the prefix `aws`\. Amazon Glacier supports all AWS\-wide condition keys in vault access and Vault Lock policies\. For example, you can use the `aws:MultiFactorAuthPresent` condition key to require multi\-factor authentication \(MFA\) when requesting an action\. For more information and a list of the AWS\-wide condition keys, see [Available Keys for Conditions](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys) in the *IAM User Guide*\.
 
-**Note**  
-Condition keys are case\-sensitive\.
-
 In addition, Amazon Glacier also provides its own condition keys that you can include in `Condition` elements in an IAM permissions policy\. Amazon Glacier–specific condition keys are applicable only when granting Amazon Glacier–specific permissions\. Amazon Glacier condition key names have the prefix `glacier:`\. The following table shows the Amazon Glacier condition keys that apply to Amazon Glacier resources\. 
 
 [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/amazonglacier/latest/dev/access-control-overview.html)


### PR DESCRIPTION
Removed note 'condition keys are case sensitive' as per IAM documentation here https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html stating that condition keys are not case sensitive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
