### PR TITLE
Updating the vault's name to match previous steps.

### DIFF
--- a/doc_source/getting-started-upload-archive-java.md
+++ b/doc_source/getting-started-upload-archive-java.md
@@ -24,7 +24,7 @@ import com.amazonaws.services.glacier.transfer.UploadResult;
 
 public class AmazonGlacierUploadArchive_GettingStarted {
 
-    public static String vaultName = "examplevault2";
+    public static String vaultName = "examplevault";
     public static String archiveToUpload = "*** provide name of file to upload ***";
     
     public static AmazonGlacierClient client;


### PR DESCRIPTION
The name of the Glacier vault is different of the previous steps.

*Issue #, if available:*

*Description of changes:* Changing the name of the vault to match previous steps of the getting started guide will help developers to get the example running more easily.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
