### PR TITLE
Update amazon-glacier-data-model.md

### DIFF
--- a/doc_source/amazon-glacier-data-model.md
+++ b/doc_source/amazon-glacier-data-model.md
@@ -68,7 +68,7 @@ In addition, the S3 Glacier data model includes job and notification\-configurat
 
 ## Job<a name="data-model-job"></a>
 
-S3 Glacier jobs can perform a select query on an archive, retrieve an archive, or get an inventory of a vault\. When performing a query on an archive, you initiate a job providing a SQL query and list of S3 Glacier archive objects\. S3 Glacier Select runs the query in place and writes the output results to Amazon S3\.
+A S3 Glacier job can perform a select query on an archive, retrieve an archive, or get an inventory of a vault\. When performing a query on an archive, you initiate a job by providing a SQL query and list of S3 Glacier archive objects\. S3 Glacier Select runs the query in place and writes the output results to Amazon S3\.
 
 Retrieving an archive and vault inventory \(list of archives\) are asynchronous operations in S3 Glacier in which you first initiate a job, and then download the job output after S3 Glacier completes the job\. 
 


### PR DESCRIPTION
On line #71 "jobs" should be singular because the description of the actions are singular. If "jobs" is kept plural then the phrases "select query on an archive, retrieve an archive, or get an inventory of a vault" should be made plural. 

Thank you for taking the time to review my proposed change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
