### PR TITLE
Update amazon-glacier-data-model.md

### DIFF
--- a/doc_source/amazon-glacier-data-model.md
+++ b/doc_source/amazon-glacier-data-model.md
@@ -97,7 +97,7 @@ For each job, S3 Glacier maintains information such as job type, description, cr
 
 ## Notification Configuration<a name="data-model-notification-config"></a>
 
-Because jobs take time to complete, S3 Glacier supports a notification mechanism to notify you when a job is complete\. You can configure a vault to send notification to an Amazon Simple Notification Service \(Amazon SNS\) topic when jobs complete\. You can specify one SNS topic per vault in the notification configuration\.
+Because jobs take time to complete, S3 Glacier supports a notification mechanism to notify you when a job is complete\. You can configure a vault to send a notification to an Amazon Simple Notification Service \(Amazon SNS\) topic when a job completes\. You can specify one SNS topic per vault in the notification configuration\.
 
 S3 Glacier stores the notification configuration as a JSON document\. The following is an example vault notification configuration:
 


### PR DESCRIPTION
On line #100 the sentence is a little more accurate and a little less awkward when the singular is used. The notification is sent after every singular job completes so it is better to describe it as such. 

Thank you for taking the time to review my proposed change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
